### PR TITLE
Tweak Nested example to work better on its own

### DIFF
--- a/examples/nested/README.md
+++ b/examples/nested/README.md
@@ -3,6 +3,8 @@ React Intl Nested Example
 
 This is a runnable example showing how to use React Intl with nested collections of string messages from different "widgets" that could be defined in separate npm packages and combined in one app.
 
+The widgets use their own internal `<IntlProvider>` to make them more usable on their own in an English-only environment.
+
 This example app creates a string messages bundle per logical widget in the app via the `scripts/group-messages.js` script.
 
 ## Running

--- a/examples/nested/src/client/components/app.js
+++ b/examples/nested/src/client/components/app.js
@@ -24,10 +24,10 @@ class App extends Component {
                         defaultMessage="React Intl Nested Messages Example"
                     />
                 </h1>
+
                 <Greeting
-                    messages={this.props.getIntlMessages('greeting')}
-                    messages={this.context.intl.locale}
                     {...this.state.user}
+                    messages={this.props.getIntlMessages('greeting')}
                 />
             </div>
         );

--- a/examples/nested/src/client/components/widgets/greeting.js
+++ b/examples/nested/src/client/components/widgets/greeting.js
@@ -1,47 +1,95 @@
+// TODO: Decide if fallback process change be changed so this component doesn't
+// have to know about `context.intl` to make sure a `locale` is specified on its
+// internal <IntlProvider>.
+
 import React, {PropTypes} from 'react';
 import {
     FormattedMessage,
     FormattedNumber,
     FormattedRelative,
     IntlProvider,
+    defineMessages,
+    intlShape,
 } from 'react-intl';
 
-const Greeting = ({messages, locale, name, unreadCount, lastLoginTime}) => (
-    <IntlProvider messages={messages} locale={locale}>
+const messages = defineMessages({
+    welcome: {
+        id: 'greeting.welcome',
+        defaultMessage: `
+            Welcome {name}, you have received {unreadCount, plural,
+                =0 {no new messages}
+                one {{formattedUnreadCount} new message}
+                other {{formattedUnreadCount} new messages}
+            }.
+        `,
+    },
+
+    last_login: {
+        id: 'greeting.last_login',
+        defaultMessage: 'You logged in {formattedLastLoginTime}.',
+    },
+});
+
+const en_messages = Object.keys(messages).reduce((en, messageName) => {
+    let {id, defaultMessage} = messages[messageName];
+    en[id] = defaultMessage.trim();
+    return en;
+}, {});
+
+const Greeting = (
+    {name, unreadCount, lastLoginTime, locale, translations}, // props
+    {intl = {}} // context
+) => (
+    <IntlProvider
+        locale={locale || intl.locale || 'en'}
+        messages={translations}
+        defaultLocale="en"
+    >
         <p>
             <FormattedMessage
-                id="greeting.welcome_message"
-                defaultMessage={`
-                    Welcome {name}, you have received {unreadCount, plural,
-                        =0 {no new messages}
-                        one {{formattedUnreadCount} new message}
-                        other {{formattedUnreadCount} new messages}
-                    } since {formattedLastLoginTime}.
-                `}
+                {...messages.welcome}
                 values={{
                     name: <b>{name}</b>,
                     unreadCount: unreadCount,
                     formattedUnreadCount: (
                         <b><FormattedNumber value={unreadCount} /></b>
                     ),
-                    formattedLastLoginTime: (
-                        <FormattedRelative
-                            value={lastLoginTime}
-                            updateInterval={1000}
-                        />
-                    ),
                 }}
             />
+            {" "}
+            {isFinite(lastLoginTime) ? (
+                <FormattedMessage
+                    {...messages.last_login}
+                    values={{
+                        formattedLastLoginTime: (
+                            <FormattedRelative
+                                value={lastLoginTime}
+                                updateInterval={1000}
+                            />
+                        ),
+                    }}
+                />
+            ) : null}
         </p>
     </IntlProvider>
 );
 
 Greeting.propTypes = {
-    messages     : PropTypes.object,
-    locale       : PropTypes.string,
     name         : PropTypes.node.isRequired,
     unreadCount  : PropTypes.number.isRequired,
-    lastLoginTime: PropTypes.any.isRequired,
+    lastLoginTime: PropTypes.any,
+    locale       : PropTypes.string,
+    translations : PropTypes.object,
+};
+
+Greeting.defaultProps = {
+    translations: en_messages,
+};
+
+// Opt-in to `context.intl` in case we're nested inside another <IntlProvider>.
+// This way we can fallback to its `locale` value if one isn't on `props`.
+Greeting.contextTypes = {
+    intl: intlShape,
 };
 
 export default Greeting;


### PR DESCRIPTION
@baer I tried taking this a step further for making the widget reusable on its own, and not require a parent `<IntlProvider>`.

Let me know what you think…